### PR TITLE
Bump cabal version bounds

### DIFF
--- a/lazyset.cabal
+++ b/lazyset.cabal
@@ -64,7 +64,7 @@ library
   -- other-extensions:    
   
   -- Other library packages from which modules are imported.
-  build-depends:       base >=4.9 && <4.10, data-ordlist >=0.4 && <0.5, containers >=0.5.8.1 && <0.6
+  build-depends:       base >=4.9 && <4.14, data-ordlist >=0.4 && <0.5, containers >=0.5.8.1 && <0.7
   
   -- Directories containing source files.
   -- hs-source-dirs:      
@@ -76,12 +76,14 @@ library
 Test-Suite settest
     type:       exitcode-stdio-1.0
     main-is:    LazySetTest.hs
+    other-modules: Data.Set.Lazy
     build-depends: base, HUnit, containers, data-ordlist
     default-language:    Haskell2010
     
 Test-Suite maptest
     type:       exitcode-stdio-1.0
     main-is:    LazyMapTest.hs
+    other-modules: Data.Set.Lazy, Data.Map.Lazier
     build-depends: base, HUnit, containers, data-ordlist
     default-language:    Haskell2010    
     
@@ -89,6 +91,6 @@ Test-Suite maptest
 Benchmark bench
     type:       exitcode-stdio-1.0
     main-is:    Benchmark.hs
+    other-modules: Data.Set.Lazy
     build-depends: base, time, containers, data-ordlist, timeit >= 1.0.0.0 && < 1.1
     default-language:    Haskell2010
-    


### PR DESCRIPTION
This bumps the cabal version bounds to be compatible with ghc 8.8.

In addition, I added `other-modules` in the cabal file to avoid a new warning that appears when it's missing.

I successfully ran the tests as well as the benchmark with the newest version.